### PR TITLE
corrects the path to the debugging doc

### DIFF
--- a/portal-sdk/templates/portalfx-testinprod.md
+++ b/portal-sdk/templates/portalfx-testinprod.md
@@ -25,7 +25,7 @@ To avoid this being a phishing risk, we enforce that your extension must be host
 
 * Navigate to [https://portal.azure.com?feature.canmodifyextensions=true&clientOptimizations=false](https://portal.azure.com?feature.canmodifyextensions=true&clientOptimizations=false)
 
-  * For other useful switches, please refer to the [debugging guide](/documentation/articles/portalfx-debugging)
+  * For other useful switches, please refer to the [debugging guide](/portal-sdk/templates/portalfx-debugging.md#diagnostic-switches)
 
 The registered extension will be saved to user settings, and available in future sessions. When using the portal in this mode, you will see a banner letting you know the state of the configured extensions has been changed:
 


### PR DESCRIPTION
##Changes

* The link was originally going to what looked like an old endpoint, this has been corrected to use the existing md file in this repository

* Added the anchor `#diagnostic-switches` since the doc specifically refers to diagnostic switches.