### PR TITLE
No-pdl instruction update

### DIFF
--- a/gallery-sdk/generated/index-gallery.md
+++ b/gallery-sdk/generated/index-gallery.md
@@ -200,7 +200,7 @@ The manifest file contains all of the metadata for your gallery item. For a visu
 
 <a name="gallery-item-specificiations-azure-gallery-package-contents-uidefinition-uidefinition-json"></a>
 #### UIDefinition (UIDefinition.json)
-The spec file contains all metadata, parameters, and other content used in the portal create experience. This file should be in the Portal folder.
+The spec file contains all metadata, parameters, and other content used in the portal create experience. This file should be in the Portal folder. Note that if you are using a <i>no-PDL</i> create experience, you should use schema version 2018-02-12 instead of 2015-02-12 in the $schema field below.
 
 ```json
 {


### PR DESCRIPTION
Gives galleryitem publishers the instructions on how to make their apps compatible with the no-pdl changes