### PR TITLE
Fixed minor spelling error in Essentials documentation

### DIFF
--- a/portal-sdk/templates/portalfx-controls-essentials.md
+++ b/portal-sdk/templates/portalfx-controls-essentials.md
@@ -46,7 +46,7 @@ When there are more than 5 items in any panes, only first 5 items in each panes 
 ##### Link
 ```typescript
 {
-    lable: "Sample Label",
+    label: "Sample Label",
     value: "Bing.com",
     onClick: new ClickableLink(ko.observable("http://www.bing.com"))
 }


### PR DESCRIPTION
Noticed a spelling error when going through the essentials docs, this is fixing that.