### PR TITLE
Add link to NuGet feed in VSTS

### DIFF
--- a/portal-sdk/templates/top-extensions-nuget.md
+++ b/portal-sdk/templates/top-extensions-nuget.md
@@ -11,6 +11,8 @@ In order to download the NuGet packages as part of an extension, developers can 
 
 Portal SDK NuGet packages are published to the Microsoft internal NuGet feed located at [https://aka.ms/portalfx/nugetfeed](https://aka.ms/portalfx/nugetfeed).  Depending on your internal build system, the configuration of how to consume this feed will vary.  For the latest guidance on consuming the feed within your build system, consult your build system's documentation. For those using 1ES systems, see the NuGet in 1ES guide located at [https://www.1eswiki.com/wiki/NuGet_in_1ES](https://www.1eswiki.com/wiki/NuGet_in_1ES).
 
+You can also [browse the feed in VSTS](https://msazure.visualstudio.com/One/Azure%20Portal/_packaging?feed=Official%40Local&_a=feed).
+
 ### Getting the NuGet packages externally
 
 PortalSDK NuGet packages are only published to Microsoft internal NuGet feeds.  If you do not have access to those feeds such as the one mentioned above you will need use those NuGet packages that are included in the Azure Portal SDK.  This is the recommended path for  [third party extension developers](portalfx-extensions-glossary-onboarding.md).


### PR DESCRIPTION
As discussed on StackOverflow: https://stackoverflow.microsoft.com/questions/107872/which-nuget-feed-should-i-use-to-get-microsoft-portal-packages

It will be useful to access NuGet feed directly to check for latest versions, and dependencies.