### PR TITLE
Changing expiration time to avoid PatLifespanPolicyViolation Exception.

### DIFF
--- a/portal-sdk/samples/setup.js
+++ b/portal-sdk/samples/setup.js
@@ -161,7 +161,7 @@ async function generateNpmPAT() {
             console.log(`Installing 'vsts-npm-auth'...`);
             await exec(`npm install -g vsts-npm-auth --registry https://registry.npmjs.org`);
         }
-        const generatePAT = "vsts-npm-auth -F -R -E 525600 -C .npmrc";
+        const generatePAT = "vsts-npm-auth -F -R -E 129600 -C .npmrc";
         console.log(`generating a readonly PAT using vsts-npm-auth...${os_1.EOL}If prompted to login, use your @microsoft.com account to authenticate against Azure Dev Ops.`);
         await exec(generatePAT);
     }
@@ -490,7 +490,7 @@ async function oneTimeConfigurationSteps() {
         - set the default npm registry (copy and paste below line to command prompt)
             npm config set registry ${registry}
         - generate a readonly PAT using vsts-npm-auth (copy and paste below line to command prompt)
-            vsts-npm-auth -F -R -E 525600 -C .npmrc
+            vsts-npm-auth -F -R -E 129600 -C .npmrc
     8. rerun this "setup.js" file`;
     const nonWindowsNPMAuthPATHInstruction = `Manual Instruction: Just as NuGet needed the credential provider npm requires a PAT for auth. Which can be configured as follows.
     1. Connect to the AzurePortal Feed https://msazure.visualstudio.com/One/_packaging?_a=feed&feed=AzurePortal


### PR DESCRIPTION
### Changes in this pull request

Changing expiration time to 90 days for `vsts-npm-auth` command.

### Why

Following the instructions to setup Azure Portal CLI at [here ](https://github.com/Azure/portaldocs/blob/dev/portal-sdk/generated/top-ap-cli.md) I was getting below error

```cmd
Error: Error: Command failed: vsts-npm-auth -F -R -E 525600 -C .npmrc
```

After the error message, following the instructions prompted for manual setup, I get the following error from `vsts-npm-auth` 
```cmd
D:\cwd\>vsts-npm-auth -F -R -E 525600 -C .npmrc

vsts-npm-auth v0.41.0.0
-----------------------
Getting new credentials for source:https://xxxxx/, scope:vso.packaging
Caught exception: PatLifespanPolicyViolation
Caught exception: PatLifespanPolicyViolation
```
This change is needed to prevent the above errors.

### Improvements

We set a lifespan of 90 days for the authorization and after these changes everything works okay.
