### PR TITLE
Correct 'Project Ibiza Partners' SG join links - allowing for gallery package uploading

### DIFF
--- a/portal-sdk/generated/top-onboarding.md
+++ b/portal-sdk/generated/top-onboarding.md
@@ -130,9 +130,9 @@ For less common scenarios, you might need to do a custom deployment. For example
 
 Join the following groups to stay current on Ibiza product road map, get news on latest features, and receive invites for Ibiza related events.
 
-* PMs and Developer Leads should join the `ibizapartners PM`  group [here](https://idweb/IdentityManagement/aspx/common/GlobalSearchResult.aspx?searchtype=e0c132db-08d8-4258-8bce-561687a8a51e&content=ibizapartners-pm&popupFromClipboard=%2Fidentitymanagement%2Faspx%2FGroups%2FEditGroup.aspx%3Fid%3Dacc725b5-30aa-4336-9c81-1867762bb945).
+* PMs and Developer Leads should join the `Project Ibiza Partners - PMs`  group [here](https://idweb.microsoft.com/IdentityManagement/aspx/groups/AllGroups.aspx?popupFromClipboard=https%3A%2F%2Fidweb.microsoft.com%2Fidentitymanagement%2Faspx%2FGroups%2FEditGroup.aspx%3Fid%3Dacc725b5-30aa-4336-9c81-1867762bb945%26UOCInitialTabName%3DGroupingMembers).
 
-* Developers should join the `ibizapartners DEV` group [here](https://idweb/IdentityManagement/aspx/common/GlobalSearchResult.aspx?searchtype=e0c132db-08d8-4258-8bce-561687a8a51e&content=ibizapartners-pm&popupFromClipboard=%2Fidentitymanagement%2Faspx%2FGroups%2FEditGroup.aspx%3Fid%3D109b1485-33c5-4c00-8e85-69d9b6176b9f).
+* Developers should join the `Project Ibiza Partners - Engineering teams` group [here](https://idweb.microsoft.com/IdentityManagement/aspx/groups/AllGroups.aspx?popupFromClipboard=https%3A%2F%2Fidweb.microsoft.com%2Fidentitymanagement%2Faspx%2FGroups%2FEditGroup.aspx%3Fid%3D109b1485-33c5-4c00-8e85-69d9b6176b9f%26UOCInitialTabName%3DGroupingMembers).
 
 * Instructions to get access to Ibiza telemetry can be found [here](top-telemetry.md#viewing-telemetry)
 


### PR DESCRIPTION
- Update the group: `Project Ibiza Partners - PMs` with a working link
- Update the group: `Project Ibiza Partners - Engineering teams` with a working link