### PR TITLE
Fixed broken declarative overview doc links

### DIFF
--- a/portal-sdk/samples/dx/views/CapabilitiesTab.md
+++ b/portal-sdk/samples/dx/views/CapabilitiesTab.md
@@ -1,4 +1,4 @@
-To add the Capabilities view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Capabilities view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/CapabilitiesTab.md
+++ b/portal-sdk/samples/dx/views/CapabilitiesTab.md
@@ -1,4 +1,4 @@
-To add the Capabilities view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Capabilities view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../generated/portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/DataBrowseTab.md
+++ b/portal-sdk/samples/dx/views/DataBrowseTab.md
@@ -1,4 +1,4 @@
-To add the DataBrowse view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the DataBrowse view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../generated/portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 
 Example for static array data source.

--- a/portal-sdk/samples/dx/views/DataBrowseTab.md
+++ b/portal-sdk/samples/dx/views/DataBrowseTab.md
@@ -1,4 +1,4 @@
-To add the DataBrowse view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the DataBrowse view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 
 Example for static array data source.

--- a/portal-sdk/samples/dx/views/GetStartedTab.md
+++ b/portal-sdk/samples/dx/views/GetStartedTab.md
@@ -1,4 +1,4 @@
-To add the Getting Started view, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Getting Started view, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](../../../generated/portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/GetStartedTab.md
+++ b/portal-sdk/samples/dx/views/GetStartedTab.md
@@ -1,4 +1,4 @@
-To add the Getting Started view, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Getting Started view, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/InformationTab.md
+++ b/portal-sdk/samples/dx/views/InformationTab.md
@@ -1,4 +1,4 @@
-To add the Informations Tab, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Informations Tab, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](../../../generated/portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/InformationTab.md
+++ b/portal-sdk/samples/dx/views/InformationTab.md
@@ -1,4 +1,4 @@
-To add the Informations Tab, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Informations Tab, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/MonitoringTab.md
+++ b/portal-sdk/samples/dx/views/MonitoringTab.md
@@ -1,4 +1,4 @@
-To add the Monitoring view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Monitoring view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/MonitoringTab.md
+++ b/portal-sdk/samples/dx/views/MonitoringTab.md
@@ -1,4 +1,4 @@
-To add the Monitoring view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Monitoring view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../generated/portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/RecommendationsTab.md
+++ b/portal-sdk/samples/dx/views/RecommendationsTab.md
@@ -1,4 +1,4 @@
-To add the Recommendations view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Recommendations view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../generated/portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/RecommendationsTab.md
+++ b/portal-sdk/samples/dx/views/RecommendationsTab.md
@@ -1,4 +1,4 @@
-To add the Recommendations view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Recommendations view, add the following example to the properties.tabs section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/TutorialsTab.md
+++ b/portal-sdk/samples/dx/views/TutorialsTab.md
@@ -1,4 +1,4 @@
-To add the Tutorials view, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Tutorials view, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {

--- a/portal-sdk/samples/dx/views/TutorialsTab.md
+++ b/portal-sdk/samples/dx/views/TutorialsTab.md
@@ -1,4 +1,4 @@
-To add the Tutorials view, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](../../../portalfx-declarative-overview.md#declarative-resource-overview-schema)
+To add the Tutorials view, add the following example to the `properties.tabs` section in the [Declarative Resource Overview schema](../../../generated/portalfx-declarative-overview.md#declarative-resource-overview-schema)
 
 ```json
 {


### PR DESCRIPTION
Linked declarative file is in another branch of the repo so I changed the relative path