### PR TITLE
Add `shell: true` to spawn process on windows machines

### DIFF
--- a/portal-sdk/samples/setup.js
+++ b/portal-sdk/samples/setup.js
@@ -535,6 +535,12 @@ async function oneTimeConfigurationSteps() {
             }
             messageBox(`One time configuration steps completed.${os_1.EOL}Running install of ap cli using command 'npm install -g @microsoft/azureportalcli@latest' ...`);
             //spawn install, no need to wait
+            if (os.platform() === "win32") {
+                // https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+                cp.spawn("npm.cmd", ["install", "-g", "@microsoft/azureportalcli@latest"], { shell: true, stdio: "inherit" });
+            } else {
+                cp.spawn("npm", ["install", "-g", "@microsoft/azureportalcli@latest"], { stdio: "inherit" });
+            }
             cp.spawn(os.platform() === "win32" ? "npm.cmd" : "npm", ["install", "-g", "@microsoft/azureportalcli@latest"], { stdio: "inherit" });
         }
         catch (error) {


### PR DESCRIPTION
This PR addresses a breaking change in the `cp.spawn` and `cp.spawnSync` command to address a security vulnerability. The breaking change now requires `shell: true` option on Windows machines otherwise the command will fail with a `error : spawn EINVAL`.

Security Release Documentation: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
GitHub Issue: https://github.com/nodejs/node/issues/52554