### PR TITLE
Update setup.js

### DIFF
--- a/portal-sdk/samples/setup.js
+++ b/portal-sdk/samples/setup.js
@@ -535,7 +535,7 @@ async function oneTimeConfigurationSteps() {
             }
             messageBox(`One time configuration steps completed.${os_1.EOL}Running install of ap cli using command 'npm install -g @microsoft/azureportalcli@latest' ...`);
             //spawn install, no need to wait
-            cp.spawn(os.platform() === "win32" ? "npm.cmd" : "npm", ["install", "-g", "@microsoft/azureportalcli@latest"], { stdio: "inherit" });
+            cp.spawn(os.platform() === "win32" ? "npm.cmd" : "npm", ["install", "-g", "@microsoft/azureportalcli@latest"], { stdio: "inherit", shell: true });
         }
         catch (error) {
             console.log(error);


### PR DESCRIPTION
Adding ``shell: true`` to cp.spawn to resolve the following error on Windows:

``
Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:414:11)
    at Object.spawn (node:child_process:761:9)
    at oneTimeConfigurationSteps (D:\repos\IDNA\Lockbox\security-LockBox\src\Microsoft.Azure.Security.LockBox.UI\Default\Extension\setup.js:534:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  errno: -4071,
  code: 'EINVAL',
  syscall: 'spawn'
}
``